### PR TITLE
Clear timer in unbind hook of debounce directive.

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -29,7 +29,7 @@
 
 ## 3.集成第三方ui框架
 
-* cude-ui（https://didi.github.io/cube-ui/#/zh-CN/docs/quick-start）
+* cube-ui（https://didi.github.io/cube-ui/#/zh-CN/docs/quick-start）
 
 
 

--- a/template/plugins/plugins.js
+++ b/template/plugins/plugins.js
@@ -18,16 +18,20 @@ Vue.config.errorHandler = (err, vm, info) => {
 
 Vue.directive('debounce', {
   inserted(el, binding) {
-    let timer;
+    el._timer = null;
 
     el.addEventListener('click', () => {
-      if (timer) {
-        clearTimeout(timer);
+      if (el._timer) {
+        clearTimeout(el._timer);
       }
 
-      timer = setTimeout(() => {
+      el._timer = setTimeout(() => {
         binding.value();
       }, 300);
     });
+  },
+  unbind(el, binding) {
+    clearTimeout(el._timer);
+    el._timer = null;
   },
 });


### PR DESCRIPTION
I find some abnormal situation when use the debounce directive, it is caused by timer.
- Proxy the timer to `el`.
- Clear the timer in `unbind` hook to ensure safety.